### PR TITLE
Increase eventbrite embedding height

### DIFF
--- a/index.md
+++ b/index.md
@@ -128,7 +128,7 @@ displayed if the 'eventbrite' field in the header is not set.
   src="https://www.eventbrite.com/tickets-external?eid={{eventbrite}}&ref=etckt"
   frameborder="0"
   width="100%"
-  height="280px"
+  height="400px"
   scrolling="auto">
 </iframe>
 {% endif %}


### PR DESCRIPTION
Change the height of the eventbrite iframe from 280 to 400px to fit all content without a scrollbar.
